### PR TITLE
Add etag header to send various response status code for request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 media
-
+.vscode/
 # If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: '3.8'
 
 services:
+  redis:
+    image: redis:latest
+    container_name: redism
+    
   db-mysql:
     image: mysql:5.7.37
     volumes:

--- a/motivator/motivations/views.py
+++ b/motivator/motivations/views.py
@@ -1,3 +1,6 @@
+import hashlib
+from rest_framework.response import Response
+from rest_framework_condition import etag
 from .models import Motivation
 from rest_framework.generics import ListAPIView
 from rest_framework.viewsets import ModelViewSet
@@ -5,17 +8,43 @@ from rest_framework.decorators import permission_classes
 from rest_framework.permissions import AllowAny
 from .serializers import MotivationSerializer
 from rest_framework.pagination import PageNumberPagination
+from django.core.cache import cache
+from rest_framework import status
 
 class PagePagination(PageNumberPagination):
     page_size = 5
     page_size_query_param = 'limit'
+
+def set_cache_key(request):
+    etag = hashlib.sha256(bytes(int(request.GET.get('page')))).hexdigest()
+    cache.set('etag'+str(request.GET.get('page')), etag)
+    return etag
+    
 
 @permission_classes((AllowAny,))
 class MotivationList(ModelViewSet):
     serializer_class = MotivationSerializer
     queryset = Motivation.objects.filter(is_visible=True)
     pagination_class = PagePagination
-        
+
+    
+
+    @etag(set_cache_key)
+    def list(self, request, *args, **kwargs):
+
+        if cache.get('etag' + str(request.GET.get('page'))) == request.META.get('HTTP_IF_NONE_MATCH'):
+            return Response(status=status.HTTP_304_NOT_MODIFIED)
+        else:
+            queryset = self.filter_queryset(self.get_queryset())
+            
+            page = self.paginate_queryset(queryset)
+            if page is not None:
+                serializer = self.get_serializer(page, many=True)
+                return self.get_paginated_response(serializer.data)
+            serializer = self.get_serializer(queryset, many=True)
+            
+            return Response(serializer.data)
+  
 
 class RandomMotivation(ListAPIView):
     queryset = Motivation.objects.filter(is_visible=True).order_by('?')[:1]

--- a/motivator/motivator/settings.py
+++ b/motivator/motivator/settings.py
@@ -85,6 +85,13 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'motivator.wsgi.application'
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': 'redis://redism:6379',
+        'TIMEOUT' : 60,
+    }
+}
 
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ Pillow==9.1.1
 PyMySQL
 drf-yasg==1.21.3
 python-dotenv==0.20.0
+redis
+django-rest-framework-condition==0.1.1


### PR DESCRIPTION
API compare ETag with request header "If none match" to send response code 304 without data if they match, else API sends usual response 